### PR TITLE
feat: add Canton chain ID support to deriveChildPublicKey

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,12 +98,22 @@ Two implementations of `ChainSignatureContract` — the MPC signing interface:
 
 ### Constants (`src/constants.ts`)
 
-Contract addresses and root public keys per environment (`TESTNET_DEV`, `TESTNET`, `MAINNET`) and chain (`ETHEREUM`, `SOLANA`). KDF chain IDs distinguish chains during key derivation.
+Contract addresses and root public keys per environment (`TESTNET_DEV`, `TESTNET`, `MAINNET`) and chain (`ETHEREUM`, `SOLANA`). KDF chain IDs distinguish chains during key derivation (`eip155:1`, `solana:5eykt...`, `canton:global`). Canton only has a KDF chain ID — no contract addresses or root public keys (signing uses Daml templates, not on-chain contracts).
 
 ## Docker Infrastructure
 
 - `docker/bitcoin/docker-compose.yml` — 3-service regtest stack: bitcoind (:18443) + electrs (:30000) + chopsticks (:3000, Mempool-compatible API with faucet)
 - `docker/cosmos/Dockerfile` — gaiad v22 node, chain-id `cosmoshub-4`, pre-funds test address `cosmos15wgtkntdf26hqan77g0kdsldcxjddypxughytg` (derived from private key `1234567890abcdef...`) with 100B uatom
+
+## Releasing
+
+Every publish must have a corresponding GitHub release with a git tag:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+gh release create vX.Y.Z --generate-notes   # auto-generates notes, tweak if needed
+```
 
 ## CI
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signet.js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A TypeScript library for handling multi-chain transactions and signatures using Signet MPC",
   "type": "module",
   "exports": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const ENVS = {
 export const CHAINS = {
   ETHEREUM: 'ETHEREUM',
   SOLANA: 'SOLANA',
+  CANTON: 'CANTON',
 } as const
 
 /**
@@ -34,7 +35,7 @@ export const ROOT_PUBLIC_KEYS: Record<keyof typeof ENVS, NajPublicKey> = {
 export const KDF_CHAIN_IDS = {
   [CHAINS.ETHEREUM]: 'eip155:1',
   [CHAINS.SOLANA]: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-  CANTON: 'canton:global',
+  [CHAINS.CANTON]: 'canton:global',
 } as const
 
 /**
@@ -59,5 +60,10 @@ export const CONTRACT_ADDRESSES: Record<
     [ENVS.TESTNET_DEV]: 'SigDuEPNeDjh3oJv7MUraPN7zaTFomS6ZWfpXwjUg4B',
     [ENVS.TESTNET]: 'SigTVbfRK9LsXWpSv9KgpabrQcFKr5hDdUwMhYsXyKg',
     [ENVS.MAINNET]: 'SigMcRMjKfnC7RDG5q4yUMZM1s5KJ9oYTPP4NmJRDRw',
+  },
+  [CHAINS.CANTON]: {
+    [ENVS.TESTNET_DEV]: '',
+    [ENVS.TESTNET]: '',
+    [ENVS.MAINNET]: '',
   },
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,7 @@ export const ROOT_PUBLIC_KEYS: Record<keyof typeof ENVS, NajPublicKey> = {
 export const KDF_CHAIN_IDS = {
   [CHAINS.ETHEREUM]: 'eip155:1',
   [CHAINS.SOLANA]: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  CANTON: 'canton:global',
 } as const
 
 /**

--- a/src/utils/cryptography.ts
+++ b/src/utils/cryptography.ts
@@ -107,7 +107,8 @@ export function deriveChildPublicKey(
   chainId: string,
   keyVersion: number
 ): UncompressedPubKeySEC1 {
-  if (chainId !== KDF_CHAIN_IDS.ETHEREUM && chainId !== KDF_CHAIN_IDS.SOLANA) {
+  const validChainIds: string[] = Object.values(KDF_CHAIN_IDS)
+  if (!validChainIds.includes(chainId)) {
     throw new Error('Invalid chain ID')
   }
 


### PR DESCRIPTION
## Summary

- Add `CANTON: 'canton:global'` to `KDF_CHAIN_IDS` in `src/constants.ts`
- Change `deriveChildPublicKey` chain ID validation from hard-coded comparisons to `Object.values(KDF_CHAIN_IDS).includes(chainId)` so future chains don't need code changes

Closes #49