### PR TITLE
chore: release v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sig-net/signet.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A TypeScript library for handling multi-chain transactions and signatures using Signet MPC",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bumps `package.json` to **0.5.1**.

The `v0.5.1` tag was already pushed and is publishing to npm (deploy.yaml) and deploying the docs (docs.yaml). This PR lands the matching version bump on `main`, since branch protection blocks direct pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)